### PR TITLE
Also build kernel with the corellium wifi patch, for mbp16,1/2/4 and mbp9,1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,6 @@ jobs:
           ls -l
 
       - name: Upload package artifact
-        if: github.ref == 'refs/heads/master'
         uses: actions/upload-artifact@v2
         with:
           name: linux-mbp-${{ steps.build.outputs.tag }}

--- a/build.sh
+++ b/build.sh
@@ -78,7 +78,9 @@ echo "" >"${KERNEL_PATH}"/.scmversion
 make -j "$(getconf _NPROCESSORS_ONLN)" deb-pkg LOCALVERSION=-mbp KDEB_PKGVERSION="${KERNEL_VERSION}-$(get_next_version mbp)"
 
 # build alternate kernel with corellium's wifi patches, for MBP16,1/2/4 and MBA9,1
-
+echo >&2 "===]> Info: Create alternative kernel with corellium wifi patch... "
+make distclean
+make clean
 # reverse other wifi patches
 while IFS= read -r file; do
   echo "==> Reverting $file"
@@ -88,6 +90,9 @@ done < <(find "${WORKING_PATH}/patches" -type f -name "*.patch" | grep "brcmfmac
 echo "==> Adding wifi-bigsur.patch"
 curl https://raw.githubusercontent.com/jamlam/mbp-16.1-linux-wifi/4c8b393ed7a874e3d9e44a2a467c1b7c74af1260/wifi-bigsur.patch \
 | patch -p1
+cp "${WORKING_PATH}/templates/default-config" "${KERNEL_PATH}/.config"
+make olddefconfig
+echo "" >"${KERNEL_PATH}"/.scmversion
 
 make -j "$(getconf _NPROCESSORS_ONLN)" deb-pkg LOCALVERSION=-mbp-16x-wifi KDEB_PKGVERSION="${KERNEL_VERSION}-$(get_next_version mbp)"
 

--- a/build.sh
+++ b/build.sh
@@ -83,7 +83,7 @@ make -j "$(getconf _NPROCESSORS_ONLN)" deb-pkg LOCALVERSION=-mbp KDEB_PKGVERSION
 while IFS= read -r file; do
   echo "==> Reverting $file"
   patch -R -p1 <"$file"
-done < <(find "${WORKING_PATH}/patches" -type f -name "*.patch" | grep "brcmfmac" | sort)
+done < <(find "${WORKING_PATH}/patches" -type f -name "*.patch" | grep "brcmfmac" | sort -r)
 
 echo "==> Adding wifi-bigsur.patch"
 curl https://raw.githubusercontent.com/jamlam/mbp-16.1-linux-wifi/4c8b393ed7a874e3d9e44a2a467c1b7c74af1260/wifi-bigsur.patch \

--- a/build.sh
+++ b/build.sh
@@ -77,6 +77,20 @@ echo "" >"${KERNEL_PATH}"/.scmversion
 # Build Deb packages
 make -j "$(getconf _NPROCESSORS_ONLN)" deb-pkg LOCALVERSION=-mbp KDEB_PKGVERSION="${KERNEL_VERSION}-$(get_next_version mbp)"
 
+# build alternate kernel with corellium's wifi patches, for MBP16,1/2/4 and MBA9,1
+
+# reverse other wifi patches
+while IFS= read -r file; do
+  echo "==> Reverting $file"
+  patch -R -p1 <"$file"
+done < <(find "${WORKING_PATH}/patches" -type f -name "*.patch" | grep "brcmfmac" | sort)
+
+echo "==> Adding wifi-bigsur.patch"
+curl https://raw.githubusercontent.com/jamlam/mbp-16.1-linux-wifi/4c8b393ed7a874e3d9e44a2a467c1b7c74af1260/wifi-bigsur.patch \
+| patch -p1
+
+make -j "$(getconf _NPROCESSORS_ONLN)" deb-pkg LOCALVERSION=-mbp-16x-wifi KDEB_PKGVERSION="${KERNEL_VERSION}-$(get_next_version mbp)"
+
 #### Copy artifacts to shared volume
 echo >&2 "===]> Info: Copying debs and calculating SHA256 ... "
 cp -rfv "${KERNEL_PATH}/.config" "/tmp/artifacts/kernel_config_${KERNEL_VERSION}"


### PR DESCRIPTION
The other wifi patches are reverted after the first kernel builds, then the corellium one is applied, and the second kernel is built.

This second kernel supports wifi on the MacBookPro16,1, MacBookPro16,2, MacBookPro16,4, and MacBookAir9,1. For this kernel, wifi firmware from macOS BigSur needs to be used instead of Mojave's firmware.

280c94bd4f8d99c66d2cca6a90c518cc0e587e1e makes it still upload the kernel as a build artifact if commits are made on other branches. This is useful for testing built kernels without making a release. Reverting/skipping this commit shouldn't break anything if you want to do that.